### PR TITLE
Update to MP6.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: maven
+  directory: "/"
+  schedule:
+    interval: monthly
+  open-pull-requests-limit: 50

--- a/finish/pom.xml
+++ b/finish/pom.xml
@@ -16,10 +16,10 @@
         <maven.compiler.target>11</maven.compiler.target>
 
         <!-- tag::defaultHttpPort[] -->
-        <liberty.var.default.http.port>9080</liberty.var.default.http.port>
+        <liberty.var.http.port>9080</liberty.var.http.port>
         <!-- end::defaultHttpPort[] -->
         <!-- tag::defaultHttpsPort[] -->
-        <liberty.var.default.https.port>9443</liberty.var.default.https.port>
+        <liberty.var.https.port>9443</liberty.var.https.port>
         <!-- end::defaultHttpsPort[] -->
         <!-- tag::appContextRoot[] -->
         <liberty.var.app.context.root>api</liberty.var.app.context.root>
@@ -37,20 +37,20 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>6.0</version>
+            <version>6.1</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.ibm.websphere.appserver.api</groupId>
             <artifactId>com.ibm.websphere.appserver.api.social</artifactId>
-            <version>1.0.75</version>
+            <version>1.0.84</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.ibm.websphere.appserver.api</groupId>
             <artifactId>com.ibm.websphere.appserver.api.jwt</artifactId>
-            <version>1.1.75</version>
+            <version>1.1.84</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>
@@ -62,13 +62,13 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.8.2</version>
+                <version>3.10</version>
             </plugin>
             <!-- Plugin to run functional tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -79,7 +79,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
             </plugin>
         </plugins>
     </build>

--- a/finish/src/main/liberty/config/server.xml
+++ b/finish/src/main/liberty/config/server.xml
@@ -4,7 +4,7 @@
         <feature>pages-3.1</feature>
         <feature>appSecurity-5.0</feature>
         <feature>transportSecurity-1.0</feature>
-        <feature>mpConfig-3.0</feature>
+        <feature>mpConfig-3.1</feature>
         <feature>restfulWSClient-3.1</feature>
         <feature>cdi-4.0</feature>
         <feature>jsonb-3.0</feature>
@@ -15,8 +15,8 @@
     </featureManager>
     <!-- end::featureManager[] -->
 
-    <httpEndpoint httpPort="${default.http.port}"
-                  httpsPort="${default.https.port}"
+    <httpEndpoint httpPort="${http.port}"
+                  httpsPort="${https.port}"
                   id="defaultHttpEndpoint"
                   host="*" />
 

--- a/start/pom.xml
+++ b/start/pom.xml
@@ -16,10 +16,10 @@
         <maven.compiler.target>11</maven.compiler.target>
 
         <!-- tag::defaultHttpPort[] -->
-        <liberty.var.default.http.port>9080</liberty.var.default.http.port>
+        <liberty.var.http.port>9080</liberty.var.http.port>
         <!-- end::defaultHttpPort[] -->
         <!-- tag::defaultHttpsPort[] -->
-        <liberty.var.default.https.port>9443</liberty.var.default.https.port>
+        <liberty.var.https.port>9443</liberty.var.https.port>
         <!-- end::defaultHttpsPort[] -->
         <!-- tag::appContextRoot[] -->
         <liberty.var.app.context.root>api</liberty.var.app.context.root>
@@ -37,20 +37,20 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>6.0</version>
+            <version>6.1</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.ibm.websphere.appserver.api</groupId>
             <artifactId>com.ibm.websphere.appserver.api.social</artifactId>
-            <version>1.0.75</version>
+            <version>1.0.84</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.ibm.websphere.appserver.api</groupId>
             <artifactId>com.ibm.websphere.appserver.api.jwt</artifactId>
-            <version>1.1.75</version>
+            <version>1.1.84</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>
@@ -62,13 +62,13 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.8.2</version>
+                <version>3.10</version>
             </plugin>
             <!-- Plugin to run functional tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -79,7 +79,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
             </plugin>
         </plugins>
     </build>

--- a/start/src/main/liberty/config/server.xml
+++ b/start/src/main/liberty/config/server.xml
@@ -3,15 +3,15 @@
         <feature>pages-3.1</feature>
         <feature>appSecurity-5.0</feature>
         <feature>transportSecurity-1.0</feature>
-        <feature>mpConfig-3.0</feature>
+        <feature>mpConfig-3.1</feature>
         <feature>restfulWSClient-3.1</feature>
         <feature>cdi-4.0</feature>
         <feature>jsonb-3.0</feature>
         <feature>jwt-1.0</feature>
     </featureManager>
 
-    <httpEndpoint httpPort="${default.http.port}"
-                  httpsPort="${default.https.port}"
+    <httpEndpoint httpPort="${http.port}"
+                  httpsPort="${https.port}"
                   id="defaultHttpEndpoint"
                   host="*" />
 


### PR DESCRIPTION
address issue: https://github.com/OpenLiberty/guides-common/issues/1021

### Review changes
- [ ] pom.xml
  - microfile-profile is 6.1, and dependencies
  - LMP 3.10
  - `default.` should be removed
  - ports `9090`,`9453`,`9091`,`9454` if guide uses local kube
- [ ] server.xml
  - feature version
- [ ] index.html
  - feature version
- [ ] update lgdev with `version-update-mp61` branch
- [ ] do end-to-end test and review content carefully
  - clone the `version-update-mp61` branch
  - if index.html has changes, make sure the links work

